### PR TITLE
create CI

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,0 +1,28 @@
+name: Build on Nightly
+
+on:
+  pull_request:
+    branches: [ master ]
+  # Also runs daily so we get a notification if a change in Flix breaks this
+  schedule:
+    - cron: '0 0 * * *'
+
+jobs:
+  build-nightly:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-java@v2.5.0
+        with:
+          java-version: 17
+          distribution: zulu
+      - run: |
+          # download today's or yesterday's Flix JAR
+          today=$(date -d today +%Y-%m-%d)
+          yesterday=$(date -d yesterday +%Y-%m-%d)
+          today_url="https://flix.dev/nightly/flix-${today}.jar"
+          yesterday_url="https://flix.dev/nightly/flix-${yesterday}.jar"
+          curl -L -f "${today_url}" > flix.jar || curl -L -f "${yesterday_url}" > flix.jar
+
+          # run tests
+          java -jar flix.jar test


### PR DESCRIPTION
This test workflow runs in 2 cases:
1. someone makes a PR to merge to master
2. it's time for the daily run

(1) is generally nice to have of course
(2) is good for community build projects IMO because you'll get notified whenever a change to Flix breaks something here (and get a ping about it once a day until you fix it)